### PR TITLE
Documentation: Add instructions, for prebuilt expo applications, for deploying to Vercel.

### DIFF
--- a/docs/pages/distribution/publishing-websites.mdx
+++ b/docs/pages/distribution/publishing-websites.mdx
@@ -224,6 +224,16 @@ Install the [Vercel CLI](https://vercel.com/docs/cli).
 </Step>
 
 <Step label="3">
+  If you have prebuilt your application, you should create a **.vercelignore** file at the root of your app and add the following:
+
+  ```txt .vercelignore
+    android/
+    ios/
+    node_modules/
+  ```
+</Step>
+
+<Step label="4">
   Deploy the website.
   
   <Terminal cmd={['$ vercel']} />


### PR DESCRIPTION
Add instructions, for prebuilt expo applications, for deploying to Vercel.

# Why

If you have ios and android directories, you will likely get the following error, when deploying to Vercel,

```
Error: Invalid request: `files` should NOT have more than 15000 items, received 21781.
```
